### PR TITLE
Clarified that LIST is to be canceled on some interactions

### DIFF
--- a/standards/rmrk1.0.0/interactions/buy.md
+++ b/standards/rmrk1.0.0/interactions/buy.md
@@ -22,6 +22,11 @@ The format of BUY is thus: `utility.batchAll(system.remark(A), balances.transfer
 A BUY that satisfies the [LIST](list.md) conditions of an item's sale immediately counts as a
 transfer of ownership. No [SEND](send.md) is necessary.
 
+## Effects
+
+This interactions cancels any pending [LIST](list.md) on the NFT with this ID. It is equivalent to
+having called LIST with a cancel on it.
+
 ## Examples
 
 Suppose we have the following NFT minted in block 5105000:

--- a/standards/rmrk1.0.0/interactions/consume.md
+++ b/standards/rmrk1.0.0/interactions/consume.md
@@ -23,6 +23,12 @@ The format of CONSUME is thus: `utility.batchAll(system.remark(A), system.remark
   "ironmaiden-20201225-zagreb-arena". The reason is arbitrary and completely up to the application.
   Correct interpretation of the reason is the responsibility of the application.
 
+  
+## Effects
+
+This interactions cancels any pending [LIST](list.md) on the NFT with this ID. It is equivalent to
+having called LIST with a cancel on it.
+
 ## Examples
 
 Suppose we have the following NFT minted in block 5105000:

--- a/standards/rmrk1.0.0/interactions/send.md
+++ b/standards/rmrk1.0.0/interactions/send.md
@@ -11,6 +11,12 @@ The format of a SEND interaction is `0x{bytes(rmrk::SEND::{version}::{id}::{reci
 - `recipient` is the address of the recipient, e.g.
   `H9eSvWe34vQDJAWckeTHWSqSChRat8bgKHG39GC1fjvEm7y`
 
+  
+## Effects
+
+This interactions cancels any pending [LIST](list.md) on the NFT with this ID. It is equivalent to
+having called LIST with a cancel on it.
+
 ## Examples
 
 ```


### PR DESCRIPTION
It was not explicit that LIST should be canceled after SEND, BUY, or CONSUME. This is now explicit. This is a hotfix and as such needs no standard version bump.