### PR TITLE
Consume clarify

### DIFF
--- a/standards/rmrk1.0.0/interactions/buy.md
+++ b/standards/rmrk1.0.0/interactions/buy.md
@@ -3,6 +3,8 @@
 The BUY interaction allows a user to immediately purchase an [NFT](../entities/nft.md) listed for
 sale using the [LIST](list.md) interaction, as long as the listing hasn't been canceled.
 
+The NFT being bought must not be [CONSUMEd](consume.md).
+
 ## Standard
 
 The BUY interaction is a

--- a/standards/rmrk1.0.0/interactions/consume.md
+++ b/standards/rmrk1.0.0/interactions/consume.md
@@ -5,6 +5,8 @@ The CONSUME interaction burns an [NFT](../entities/nft.md) for a specific purpos
 This is useful when NFTs are spendable like with in-game potions, one-time votes in DAOs, or concert
 tickets.
 
+The NFT being consumed must not already be [CONSUMEd](consume.md).
+
 ## Standard
 
 The CONSUME interaction is a
@@ -23,7 +25,6 @@ The format of CONSUME is thus: `utility.batchAll(system.remark(A), system.remark
   "ironmaiden-20201225-zagreb-arena". The reason is arbitrary and completely up to the application.
   Correct interpretation of the reason is the responsibility of the application.
 
-  
 ## Effects
 
 This interactions cancels any pending [LIST](list.md) on the NFT with this ID. It is equivalent to

--- a/standards/rmrk1.0.0/interactions/emote.md
+++ b/standards/rmrk1.0.0/interactions/emote.md
@@ -2,6 +2,8 @@
 
 React to an [NFT](../entities/nft.md) with an emoticon.
 
+The NFT being emoted on must not be [CONSUMEd](consume.md).
+
 ## Standard
 
 The format of a EMOTE interaction is `0x{bytes(rmrk::EMOTE::{version}::{id}::{emotion})}`.

--- a/standards/rmrk1.0.0/interactions/list.md
+++ b/standards/rmrk1.0.0/interactions/list.md
@@ -4,6 +4,8 @@ A LIST interaction lists an NFT as available for sale. The NFT can be instantly 
 can be canceled, and is automatically considered canceled when a [BUY](./buy.md) is executed on top
 of a given LIST.
 
+The NFT being listed must not be [CONSUMEd](consume.md).
+
 ## Standard
 
 The format of a LIST interaction is `0x{bytes(rmrk::LIST::{version}::{id}::{price})}`.

--- a/standards/rmrk1.0.0/interactions/send.md
+++ b/standards/rmrk1.0.0/interactions/send.md
@@ -2,6 +2,8 @@
 
 Send an [NFT](../entities/nft.md) to an arbitrary recipient.
 
+The NFT being sent must not be [CONSUMEd](consume.md).
+
 ## Standard
 
 The format of a SEND interaction is `0x{bytes(rmrk::SEND::{version}::{id}::{recipient})}`.
@@ -11,7 +13,6 @@ The format of a SEND interaction is `0x{bytes(rmrk::SEND::{version}::{id}::{reci
 - `recipient` is the address of the recipient, e.g.
   `H9eSvWe34vQDJAWckeTHWSqSChRat8bgKHG39GC1fjvEm7y`
 
-  
 ## Effects
 
 This interactions cancels any pending [LIST](list.md) on the NFT with this ID. It is equivalent to


### PR DESCRIPTION
It was only implied that a consumed item cannot be interacted with. This is now explicit.